### PR TITLE
feat: Add output path prompting and validation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,36 +47,37 @@ version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.6"
+version = "3.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2109dbce0e72be3ec00bed26e6a7479ca384ad226efdd66db8fa2e3a38c83125"
+checksum = "ca3534e77181a9cc07539ad51f2141fe32f6c3ffd4df76db8ad92346b003ae4e"
 dependencies = [
  "anstyle",
- "windows-sys 0.59.0",
+ "once_cell",
+ "windows-sys",
 ]
 
 [[package]]
 name = "anyhow"
-version = "1.0.93"
+version = "1.0.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c95c10ba0b00a02636238b814946408b1322d5ac4760326e6fb8ec956d85775"
+checksum = "dcfed56ad506cb2c684a14971b8861fdc3baaaae314b9e5f9bb532cbe3ba7a4f"
 
 [[package]]
 name = "bitflags"
-version = "2.6.0"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
+checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
 
 [[package]]
 name = "bstr"
-version = "1.11.0"
+version = "1.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a68f1f47cdf0ec8ee4b941b2eee2a80cb796db73118c0dd09ac63fbe405be22"
+checksum = "531a9155a481e2ee699d4f98f43c0ca4ff8ee1bfd55c31e9e98fb29d2b176fe0"
 dependencies = [
  "memchr",
  "serde",
@@ -84,9 +85,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.16.0"
+version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
+checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
 
 [[package]]
 name = "cfg-if"
@@ -96,9 +97,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "4.5.21"
+version = "4.5.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb3b4b9e5a7c7514dfa52869339ee98b3156b0bfb4e8a77c4ff4babb64b1604f"
+checksum = "d8aa86934b44c19c50f87cc2790e19f54f7a67aedb64101c2e1a2e5ecfb73944"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -106,9 +107,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.21"
+version = "4.5.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b17a95aa67cc7b5ebd32aa5370189aa0d79069ef1c64ce893bd30fb24bff20ec"
+checksum = "2414dbb2dd0695280da6ea9261e327479e9d37b0630f6b53ba2a11c60c679fd9"
 dependencies = [
  "anstream",
  "anstyle",
@@ -118,9 +119,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.18"
+version = "4.5.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ac6a0c7b1a9e9a5186361f67dfa1b88213572f427fb9ab038efb2bd8c582dab"
+checksum = "09176aae279615badda0765c0c0b3f6ed53f4709118af73cf4655d85d1530cd7"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -130,9 +131,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afb84c814227b90d6895e01398aee0d8033c00e7466aca416fb6a8e0eb19d8a7"
+checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
 name = "codepack"
@@ -156,22 +157,22 @@ checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
 name = "console"
-version = "0.15.8"
+version = "0.15.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e1f83fc076bd6dd27517eacdf25fef6c4dfe5f1d7448bafaaf3a26f13b5e4eb"
+checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
 dependencies = [
- "encode_unicode 0.3.6",
- "lazy_static",
+ "encode_unicode",
  "libc",
- "unicode-width 0.1.14",
- "windows-sys 0.52.0",
+ "once_cell",
+ "unicode-width 0.2.0",
+ "windows-sys",
 ]
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
@@ -188,9 +189,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.20"
+version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "csv"
@@ -206,9 +207,9 @@ dependencies = [
 
 [[package]]
 name = "csv-core"
-version = "0.1.11"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5efa2b3d7902f4b634a20cae3c9c4e6209dc4779feb6863329607560143efa70"
+checksum = "7d02f3b0da4c6504f86e9cd789d8dbafab48c2321be74e9987593de5a894d93d"
 dependencies = [
  "memchr",
 ]
@@ -236,31 +237,25 @@ dependencies = [
 
 [[package]]
 name = "encode_unicode"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
-
-[[package]]
-name = "encode_unicode"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "errno"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
+checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys",
 ]
 
 [[package]]
 name = "fastrand"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "486f806e73c5707928240ddc295403b1b93c96a02038563881c4a2fd84b81ac4"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "getrandom"
@@ -270,14 +265,26 @@ checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73fea8450eea4bac3940448fb7ae50d91f034f941199fcd9d909a5a07aa455f0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasi 0.14.2+wasi-0.2.4",
 ]
 
 [[package]]
 name = "globset"
-version = "0.4.15"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15f1ce686646e7f1e19bf7d5533fe443a45dbfb990e00629110797578b42fb19"
+checksum = "54a1028dfc5f5df5da8a56a73e6c153c9a9708ec57232470703592a3f18e49f5"
 dependencies = [
  "aho-corasick",
  "bstr",
@@ -294,9 +301,9 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
+checksum = "fbd780fe5cc30f81464441920d82ac8740e2e46b29a6fad543ddd075229ce37e"
 
 [[package]]
 name = "ignore"
@@ -316,9 +323,9 @@ dependencies = [
 
 [[package]]
 name = "indicatif"
-version = "0.17.9"
+version = "0.17.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbf675b85ed934d3c67b5c5469701eec7db22689d0a2139d856e0925fa28b281"
+checksum = "183b3088984b400f4cfac3620d5e076c84da5364016b4f49473de574b2586235"
 dependencies = [
  "console",
  "number_prefix",
@@ -329,13 +336,13 @@ dependencies = [
 
 [[package]]
 name = "is-terminal"
-version = "0.4.13"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "261f68e344040fbd0edea105bef17c66edf46f984ddb1115b775ce31be948f4b"
+checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -346,16 +353,17 @@ checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "itoa"
-version = "1.0.11"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "js-sys"
-version = "0.3.72"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a88f1bda2bd75b0452a14784937d796722fdebfe50df998aeb3f0b7603019a9"
+checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
 dependencies = [
+ "once_cell",
  "wasm-bindgen",
 ]
 
@@ -367,9 +375,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.162"
+version = "0.2.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18d287de67fe55fd7e1581fe933d965a5a9477b38e949cfa9f8574ef01506398"
+checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
 
 [[package]]
 name = "libredox"
@@ -383,15 +391,15 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.14"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
+checksum = "fe7db12097d22ec582439daf8618b8fdd1a7bef6270e9af3b1ebcd30893cf413"
 
 [[package]]
 name = "log"
-version = "0.4.22"
+version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
+checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
 name = "memchr"
@@ -407,15 +415,15 @@ checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "once_cell"
-version = "1.20.2"
+version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "portable-atomic"
-version = "1.9.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc9c68a3f6da06753e9335d63e27f6b9754dd1920d941135b7ea8224f141adb2"
+checksum = "350e9b48cbc6b0e028b0473b114454c6316e57336ee184ceab6e53f72c178b3e"
 
 [[package]]
 name = "prettytable"
@@ -424,7 +432,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46480520d1b77c9a3482d39939fcf96831537a250ec62d4fd8fbdf8e0302e781"
 dependencies = [
  "csv",
- "encode_unicode 1.0.0",
+ "encode_unicode",
  "is-terminal",
  "lazy_static",
  "term",
@@ -433,21 +441,27 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.89"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f139b0662de085916d1fb67d2b4169d1addddda1919e696f3252b740b629986e"
+checksum = "a31971752e70b8b2686d7e46ec17fb38dad4051d94024c88df49b667caea9c84"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.37"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
+checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "5.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
 
 [[package]]
 name = "redox_users"
@@ -455,7 +469,7 @@ version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
  "libredox",
  "thiserror",
 ]
@@ -479,28 +493,28 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "rustix"
-version = "0.38.40"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99e4ea3e1cdc4b559b8e5650f9c8e5998e3e5c1343b4eaf034565f32318d63c0"
+checksum = "d97817398dd4bb2e6da002002db259209759911da105da92bec29ccb12cf58bf"
 dependencies = [
  "bitflags",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys",
 ]
 
 [[package]]
 name = "rustversion"
-version = "1.0.18"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e819f2bc632f285be6d7cd36e25940d45b2391dd6d9b939e79de557f7014248"
+checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
 
 [[package]]
 name = "ryu"
-version = "1.0.18"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "same-file"
@@ -513,18 +527,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.215"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6513c1ad0b11a9376da888e3e0baa0077f1aed55c17f50e7b2397136129fb88f"
+checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.215"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad1e866f866923f252f05c889987993144fb74e722403468a4ebd70c3cd756c0"
+checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -539,9 +553,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.87"
+version = "2.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25aa4ce346d03a6dcd68dd8b4010bcb74e54e62c90c573f394c46eae99aba32d"
+checksum = "b09a44accad81e1ba1cd74a32461ba89dee89095ba17b32f5d03683b1b1fc2a0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -550,15 +564,15 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.14.0"
+version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28cce251fcbc87fac86a866eeb0d6c2d536fc16d06f184bb61aeae11aa4cee0c"
+checksum = "7437ac7763b9b123ccf33c338a5cc1bac6f69b45a136c19bdd8a65e3916435bf"
 dependencies = [
- "cfg-if",
  "fastrand",
+ "getrandom 0.3.2",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -594,9 +608,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.13"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
+checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
 name = "unicode-width"
@@ -633,10 +647,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
-name = "wasm-bindgen"
-version = "0.2.95"
+name = "wasi"
+version = "0.14.2+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "128d1e363af62632b8eb57219c8fd7877144af57558fb2ef0368d0087bddeb2e"
+checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+dependencies = [
+ "wit-bindgen-rt",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -645,13 +668,12 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.95"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb6dd4d3ca0ddffd1dd1c9c04f94b868c37ff5fac97c30b97cff2d74fce3a358"
+checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
 dependencies = [
  "bumpalo",
  "log",
- "once_cell",
  "proc-macro2",
  "quote",
  "syn",
@@ -660,9 +682,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.95"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e79384be7f8f5a9dd5d7167216f022090cf1f9ec128e6e6a482a2cb5c5422c56"
+checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -670,9 +692,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.95"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26c6ab57572f7a24a4985830b120de1594465e5d500f24afe89e16b4e833ef68"
+checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -683,9 +705,12 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.95"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65fc09f10666a9f147042251e0dda9c18f166ff7de300607007e96bdebc1068d"
+checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+dependencies = [
+ "unicode-ident",
+]
 
 [[package]]
 name = "web-time"
@@ -719,7 +744,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -727,15 +752,6 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
-name = "windows-sys"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets",
-]
 
 [[package]]
 name = "windows-sys"
@@ -809,3 +825,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "wit-bindgen-rt"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
+dependencies = [
+ "bitflags",
+]

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # `codepack`
 
-[![crates.io](https://img.shields.io/crates/v/codepack.svg)](https://crates.io/crates/codepack) [![Web](https://github.com/JasonLovesDoggo/codepack/actions/workflows/web.yml/badge.svg)](https://github.com/JasonLovesDoggo/codepack/actions/workflows/web.yml)  [![Release](https://github.com/JasonLovesDoggo/codepack/actions/workflows/release.yml/badge.svg)](https://github.com/JasonLovesDoggo/codepack/actions/workflows/release.yml)
+[![crates.io](https://img.shields.io/crates/v/codepack.svg)](https://crates.io/crates/codepack) [![Web](https://github.com/JasonLovesDoggo/codepack/actions/workflows/web.yml/badge.svg)](https://github.com/JasonLovesDoggo/codepack/actions/workflows/web.yml) [![Release](https://github.com/JasonLovesDoggo/codepack/actions/workflows/release.yml/badge.svg)](https://github.com/JasonLovesDoggo/codepack/actions/workflows/release.yml)
 
-**`codepack`** transforms directories into *LLM-friendly* text files.
+**`codepack`** transforms directories into _LLM-friendly_ text files.
 
-A *lightning-fast* tool that converts the contents of a directory into a single, LLM-friendly text file, making it easy to process and analyze data with Large Language Models.
+A _lightning-fast_ tool that converts the contents of a directory into a single, LLM-friendly text file, making it easy to process and analyze data with Large Language Models.
 
 ## Installation
 
@@ -23,17 +23,21 @@ Alternatively, you can install `codepack` from source with Rust's package manage
 ```sh
 cargo install codepack
 ```
+
 This will download, build, and install the latest version of codepack.
 
 ## Quickstart
+
 Once installed, simply run:
 
-```bash 
+```bash
 codepack /path/to/directory
 ```
+
 By default, codepack will process the directory and output a .txt file with the contents of the files inside the directory. If you don't specify an output file, it will generate one based on the directory name and the number of files processed.
 
 ## Features
+
 - **Lightning Fast**: `codepack` is optimized for speed, ensuring that even large directories are processed efficiently.
 - **Customizable Output**: Specify the output file name with the `-o` option, or let `codepack` generate one for you.
 - **Selective File Processing**: Use the `-e` or `--extension` flag to include specific file types (e.g., `.rs`, `.toml`).
@@ -41,6 +45,7 @@ By default, codepack will process the directory and output a .txt file with the 
 - **Powerful Filtering**: Filter files based on file names, paths, and content using the `-f` or `--filter` option.
 
 ### Filtering with codepack
+
 Codepack supports three types of filters:
 
 1. File Name Filters: Filter files based on their names using the file.name= prefix followed by the pattern to match.
@@ -60,6 +65,7 @@ Note: Content filters are applied after the file has been read, so this can be s
 You can combine multiple filters using multiple `-f` or `--filter` options. Codepack uses `OR` logic for filtering, so a file will be included if it matches any of the provided filters.
 
 ## Usage
+
 ```bash
 codepack [OPTIONS] <DIRECTORY_PATH>
 
@@ -69,10 +75,10 @@ Options:
 -h, --help              Show this message
 -e, --extension <EXT>   Include files with the specified extension(s) (e.g., -e rs -e toml)
 -o, --output <OUTPUT>   Specify the output file path (optional)
--s, --suppress-prompt   Suppress the description of the file format in the output
--f  --filter <FILTER>      Filter files based on name, path, or content (e.g., -f "file.name=main.rs").
+--suppress-prompt   Suppress the description of the file format in the output
+--force   Overwrite output file without confirmation
+-f,  --filter <FILTER>      Filter files based on name, path, or content (e.g., -f "file.name=main.rs").
 ```
-
 
 Examples
 Convert a directory to a .txt file with a custom output name:
@@ -80,6 +86,7 @@ Convert a directory to a .txt file with a custom output name:
 ```bash
 codepack /path/to/my/code -o my_code.txt
 ```
+
 Process only `.rs` and `.toml` files from a directory:
 
 ```bash
@@ -87,7 +94,9 @@ codepack /path/to/my/code -e rs -e toml
 ```
 
 ## Contributing
+
 We welcome contributions to codepack! Please feel free to submit issues or pull requests on GitHub.
 
 ## License
+
 codepack is distributed under the terms of the GPL-3.0 License. See the [LICENSE](./LICENSE) file for details.

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,6 +29,10 @@ struct Args {
     #[arg(long)]
     suppress_prompt: bool,
 
+    /// Overwrite output file without confirmation
+    #[arg(long)]
+    force: bool,
+
     #[arg(short = 'f', long = "filter", action = clap::ArgAction::Append)]
     filters: Vec<String>,
 }
@@ -70,6 +74,7 @@ fn main() -> Result<()> {
         args.excluded_files,
         args.suppress_prompt,
         args.output.clone().unwrap(),
+        args.force,
         filters,
     );
 

--- a/tests/filtering.rs
+++ b/tests/filtering.rs
@@ -8,6 +8,7 @@ fn test_should_process_file_empty_path() {
         vec!["excluded.rs".to_string()],
         false,
         String::new(),
+        false,
         vec![],
     );
     let path = Path::new("");
@@ -21,6 +22,7 @@ fn test_should_process_file_excluded_by_name() {
         vec!["test.lock".to_string()],
         false,
         String::new(),
+        false,
         vec![],
     );
     let path = Path::new("test.lock");
@@ -29,16 +31,28 @@ fn test_should_process_file_excluded_by_name() {
 
 #[test]
 fn test_should_process_file_excluded_by_extension() {
-    let processor =
-        DirectoryProcessor::new(vec!["rs".to_string()], vec![], false, String::new(), vec![]);
+    let processor = DirectoryProcessor::new(
+        vec!["rs".to_string()],
+        vec![],
+        false,
+        String::new(),
+        false,
+        vec![],
+    );
     let path = Path::new("main.py");
     assert!(!processor.should_process_file(path));
 }
 
 #[test]
 fn test_should_process_file_included_by_extension() {
-    let processor =
-        DirectoryProcessor::new(vec!["rs".to_string()], vec![], false, String::new(), vec![]);
+    let processor = DirectoryProcessor::new(
+        vec!["rs".to_string()],
+        vec![],
+        false,
+        String::new(),
+        false,
+        vec![],
+    );
     let path = Path::new("main.rs");
     assert!(processor.should_process_file(path));
 }
@@ -50,6 +64,7 @@ fn test_should_process_file_filter_file_name() {
         vec![],
         false,
         String::new(),
+        false,
         vec![Filter::FileName("main.rs".to_string())],
     );
     let path = Path::new("main.rs");
@@ -66,6 +81,7 @@ fn test_should_process_file_filter_path_contains() {
         vec![],
         false,
         String::new(),
+        false,
         vec![Filter::PathContains("src".to_string())],
     );
     let path = Path::new("src/main.rs");
@@ -82,6 +98,7 @@ fn test_should_process_file_combined_filters() {
         vec![],
         false,
         String::new(),
+        false,
         vec![
             Filter::FileName("main".to_string()),
             Filter::PathContains("src".to_string()),
@@ -104,6 +121,7 @@ fn test_should_process_file_exclusion_and_filters() {
         vec!["excluded.rs".to_string()],
         false,
         String::new(),
+        false,
         vec![Filter::PathContains("src".to_string())],
     );
     let excluded_path = Path::new("src/excluded.rs");

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -17,6 +17,7 @@ fn test_integration() -> Result<(), Box<dyn std::error::Error>> {
         vec![],
         false,
         output_file_path.to_str().unwrap().to_string(),
+        false,
         vec![],
     );
     let files_processed = processor.run(temp_dir.path())?;

--- a/tests/unit_tests.rs
+++ b/tests/unit_tests.rs
@@ -3,22 +3,28 @@ use std::path::Path;
 
 #[test]
 fn test_should_process_file_empty_path() {
-    let processor = DirectoryProcessor::new(vec![], vec![], false, String::new(), vec![]);
+    let processor = DirectoryProcessor::new(vec![], vec![], false, String::new(), false, vec![]);
     let path = Path::new("");
     assert!(!processor.should_process_file(path));
 }
 
 #[test]
 fn test_should_process_file_regular_file() {
-    let processor = DirectoryProcessor::new(vec![], vec![], false, String::new(), vec![]);
+    let processor = DirectoryProcessor::new(vec![], vec![], false, String::new(), false, vec![]);
     let path = Path::new("test.txt");
     assert!(processor.should_process_file(path));
 }
 
 #[test]
 fn test_should_process_file_included_extension() {
-    let processor =
-        DirectoryProcessor::new(vec!["rs".to_string()], vec![], false, String::new(), vec![]);
+    let processor = DirectoryProcessor::new(
+        vec!["rs".to_string()],
+        vec![],
+        false,
+        String::new(),
+        false,
+        vec![],
+    );
     let path = Path::new("main.rs");
     assert!(processor.should_process_file(path));
 }
@@ -29,6 +35,7 @@ fn test_should_process_file_excluded_file() {
         vec!["main.rs".to_string()],
         false,
         String::new(),
+        false,
         vec![],
     );
     let path = Path::new("main.rs");
@@ -42,6 +49,7 @@ fn test_should_process_file_excluded_file_by_name() {
         vec!["status".to_string()],
         false,
         String::new(),
+        false,
         vec![],
     );
     let path = Path::new("/home/json/code/src/status");
@@ -55,8 +63,76 @@ fn test_should_process_file_excluded_globed_file() {
         vec!["*.py".to_string()],
         false,
         String::new(),
+        false,
         vec![],
     );
     let path = Path::new("script.py");
     assert!(!processor.should_process_file(path));
+}
+
+#[test]
+fn test_validate_output_file() {
+    let temp_dir = tempfile::TempDir::new().expect("Failed to create temp dir");
+    let test_file_path = temp_dir.path().join("test.txt");
+    std::fs::write(&test_file_path, "This is a test file.").expect("Failed to write file");
+
+    let output_path = test_file_path.to_str().unwrap().to_string();
+    let mut mock_input = std::io::Cursor::new(b"n\n");
+    let mut mock_output = Vec::new();
+
+    let processor = DirectoryProcessor::new(
+        vec!["txt".to_string()],
+        vec![],
+        false,
+        output_path.clone(),
+        false,
+        vec![],
+    );
+
+    // if user chooses not to overwrite, should return false
+    assert!(!processor
+        .validate_output_file(
+            output_path.clone(),
+            false,
+            &mut mock_input,
+            &mut mock_output
+        )
+        .expect("Failed to validate output file"));
+
+    // if forced overwrite, should return true
+    assert!(processor
+        .validate_output_file(output_path, true, &mut mock_input, &mut mock_output)
+        .expect("Failed to validate output file"));
+}
+
+#[test]
+fn test_run_and_validate_output_file() {
+    let temp_dir = tempfile::TempDir::new().expect("Failed to create temp dir");
+    let output_path = temp_dir
+        .path()
+        .join("test.txt")
+        .to_str()
+        .unwrap()
+        .to_string();
+
+    let processor = DirectoryProcessor::new(
+        vec!["txt".to_string()],
+        vec![],
+        false,
+        output_path.clone(),
+        false,
+        vec![],
+    );
+
+    processor
+        .run(temp_dir.path())
+        .expect("Failed to run processor");
+
+    let mut mock_input = std::io::Cursor::new(b"n\n");
+    let mut mock_output = Vec::new();
+
+    // should return true because it is processor generated content
+    assert!(processor
+        .validate_output_file(output_path, false, &mut mock_input, &mut mock_output)
+        .expect("Failed to validate output file"));
 }


### PR DESCRIPTION
Closes #2.

This PR adds a `validate_output_path` function that checks the output path to see if it has valid data, which may be overwritten. If there is data, it **prompts** the user if they would like to overwrite it, and it detects auto generated data and suppresses the redundant prompting. It also adds a `--force` flag that ignores the validation which can be used for automation, and updates the `README.md` accordingly.